### PR TITLE
feat: add profit report, rent & expenses management

### DIFF
--- a/prisma/migrations/20260414155033_add_rent_table/migration.sql
+++ b/prisma/migrations/20260414155033_add_rent_table/migration.sql
@@ -1,0 +1,26 @@
+-- CreateTable
+CREATE TABLE "Rent" (
+    "id" SERIAL NOT NULL,
+    "startDate" DATE NOT NULL,
+    "endDate" DATE NOT NULL,
+    "amount" INTEGER NOT NULL,
+    "comment" TEXT,
+    "createdAt" TIMESTAMP(3) NOT NULL DEFAULT CURRENT_TIMESTAMP,
+    "updatedAt" TIMESTAMP(3) NOT NULL,
+    "organizationId" INTEGER NOT NULL,
+    "locationId" INTEGER NOT NULL,
+
+    CONSTRAINT "Rent_pkey" PRIMARY KEY ("id")
+);
+
+-- CreateIndex
+CREATE INDEX "Rent_organizationId_idx" ON "Rent"("organizationId");
+
+-- CreateIndex
+CREATE INDEX "Rent_locationId_idx" ON "Rent"("locationId");
+
+-- AddForeignKey
+ALTER TABLE "Rent" ADD CONSTRAINT "Rent_organizationId_fkey" FOREIGN KEY ("organizationId") REFERENCES "Organization"("id") ON DELETE CASCADE ON UPDATE CASCADE;
+
+-- AddForeignKey
+ALTER TABLE "Rent" ADD CONSTRAINT "Rent_locationId_fkey" FOREIGN KEY ("locationId") REFERENCES "Location"("id") ON DELETE CASCADE ON UPDATE CASCADE;

--- a/prisma/migrations/20260414162653_add_expense_table/migration.sql
+++ b/prisma/migrations/20260414162653_add_expense_table/migration.sql
@@ -1,0 +1,19 @@
+-- CreateTable
+CREATE TABLE "Expense" (
+    "id" SERIAL NOT NULL,
+    "name" TEXT NOT NULL,
+    "amount" INTEGER NOT NULL,
+    "date" DATE NOT NULL,
+    "comment" TEXT,
+    "createdAt" TIMESTAMP(3) NOT NULL DEFAULT CURRENT_TIMESTAMP,
+    "updatedAt" TIMESTAMP(3) NOT NULL,
+    "organizationId" INTEGER NOT NULL,
+
+    CONSTRAINT "Expense_pkey" PRIMARY KEY ("id")
+);
+
+-- CreateIndex
+CREATE INDEX "Expense_organizationId_idx" ON "Expense"("organizationId");
+
+-- AddForeignKey
+ALTER TABLE "Expense" ADD CONSTRAINT "Expense_organizationId_fkey" FOREIGN KEY ("organizationId") REFERENCES "Organization"("id") ON DELETE CASCADE ON UPDATE CASCADE;

--- a/prisma/schema.prisma
+++ b/prisma/schema.prisma
@@ -125,6 +125,8 @@ model Organization {
   paymentMethods                 PaymentMethod[]
   taxConfig                      TaxConfig?
   snoozedAlerts                  SnoozedAlert[]
+  rents                          Rent[]
+  expenses                       Expense[]
 
   @@unique([slug])
   @@map("Organization")
@@ -333,6 +335,42 @@ model Location {
   organization   Organization @relation(fields: [organizationId], references: [id], onDelete: Cascade)
 
   groups Group[]
+  rents  Rent[]
+
+  @@index([organizationId])
+}
+
+model Rent {
+  id        Int      @id @default(autoincrement())
+  startDate DateTime @db.Date
+  endDate   DateTime @db.Date
+  amount    Int
+  comment   String?
+  createdAt DateTime @default(now())
+  updatedAt DateTime @updatedAt
+
+  // Relations
+  organizationId Int
+  locationId     Int
+  organization   Organization @relation(fields: [organizationId], references: [id], onDelete: Cascade)
+  location       Location     @relation(fields: [locationId], references: [id], onDelete: Cascade)
+
+  @@index([organizationId])
+  @@index([locationId])
+}
+
+model Expense {
+  id        Int      @id @default(autoincrement())
+  name      String
+  amount    Int
+  date      DateTime @db.Date
+  comment   String?
+  createdAt DateTime @default(now())
+  updatedAt DateTime @updatedAt
+
+  // Relations
+  organizationId Int
+  organization   Organization @relation(fields: [organizationId], references: [id], onDelete: Cascade)
 
   @@index([organizationId])
 }

--- a/src/app/[slug]/finances/expenses/page.tsx
+++ b/src/app/[slug]/finances/expenses/page.tsx
@@ -1,0 +1,31 @@
+import {
+  Card,
+  CardAction,
+  CardContent,
+  CardDescription,
+  CardHeader,
+  CardTitle,
+} from '@/src/components/ui/card'
+import AddExpenseButton from '@/src/features/finances/expenses/components/add-expense-button'
+import ExpenseTable from '@/src/features/finances/expenses/components/expense-table'
+
+export const metadata = { title: 'Прочие расходы' }
+
+export default function Page() {
+  return (
+    <div className="grid min-h-0 flex-1 grid-cols-1">
+      <Card>
+        <CardHeader>
+          <CardTitle>Прочие расходы</CardTitle>
+          <CardDescription>Управление прочими расходами организации</CardDescription>
+          <CardAction>
+            <AddExpenseButton />
+          </CardAction>
+        </CardHeader>
+        <CardContent className="overflow-hidden">
+          <ExpenseTable />
+        </CardContent>
+      </Card>
+    </div>
+  )
+}

--- a/src/app/[slug]/finances/profit/page.tsx
+++ b/src/app/[slug]/finances/profit/page.tsx
@@ -1,0 +1,7 @@
+import Profit from '@/src/features/finances/profit/components/profit'
+
+export const metadata = { title: 'Прибыль' }
+
+export default function Page() {
+  return <Profit />
+}

--- a/src/app/[slug]/finances/rent/page.tsx
+++ b/src/app/[slug]/finances/rent/page.tsx
@@ -1,0 +1,7 @@
+import RentExpenses from '@/src/features/finances/rent/components/rent-expenses'
+
+export const metadata = { title: 'Аренда' }
+
+export default function Page() {
+  return <RentExpenses />
+}

--- a/src/components/sidebar/mobile-header.tsx
+++ b/src/components/sidebar/mobile-header.tsx
@@ -23,6 +23,7 @@ const pageTitles: Record<string, string> = {
   '/finances/revenue': 'Выручка',
   '/finances/salaries': 'Зарплаты',
   '/finances/advances': 'Авансы',
+  '/finances/profit': 'Прибыль',
   '/finances/payment-methods': 'Методы оплаты',
   '/shop/products': 'Товары',
   '/shop/categories': 'Категории',

--- a/src/components/sidebar/nav-platform.tsx
+++ b/src/components/sidebar/nav-platform.tsx
@@ -141,6 +141,23 @@ const navLists: NavGroup[] = [
         featureKey: 'finances.salaries',
       },
       {
+        title: 'Прибыль',
+        url: '/finances/profit',
+        roles: ['owner'],
+        featureKey: 'finances.profit',
+      },
+      {
+        title: 'Аренда',
+        url: '/finances/rent',
+        roles: ['owner'],
+        featureKey: 'finances.rent',
+      },
+      {
+        title: 'Прочие расходы',
+        url: '/finances/expenses',
+        roles: ['owner'],
+      },
+      {
         title: 'Методы оплаты',
         url: '/finances/payment-methods',
         roles: ['owner'],

--- a/src/features/finances/expenses/actions.ts
+++ b/src/features/finances/expenses/actions.ts
@@ -1,0 +1,47 @@
+'use server'
+
+import prisma from '@/src/lib/db/prisma'
+import { authAction } from '@/src/lib/safe-action'
+import { CreateExpenseSchema, DeleteExpenseSchema, UpdateExpenseSchema } from './schemas'
+
+export const getExpenses = authAction
+  .metadata({ actionName: 'getExpenses' })
+  .action(async ({ ctx }) => {
+    return await prisma.expense.findMany({
+      where: { organizationId: ctx.session.organizationId! },
+      orderBy: { date: 'desc' },
+    })
+  })
+
+export const createExpense = authAction
+  .metadata({ actionName: 'createExpense' })
+  .inputSchema(CreateExpenseSchema)
+  .action(async ({ ctx, parsedInput }) => {
+    await prisma.expense.create({
+      data: {
+        ...parsedInput,
+        date: new Date(parsedInput.date),
+        organizationId: ctx.session.organizationId!,
+      },
+    })
+  })
+
+export const updateExpense = authAction
+  .metadata({ actionName: 'updateExpense' })
+  .inputSchema(UpdateExpenseSchema)
+  .action(async ({ ctx, parsedInput }) => {
+    const { id, ...data } = parsedInput
+    await prisma.expense.update({
+      where: { id, organizationId: ctx.session.organizationId! },
+      data,
+    })
+  })
+
+export const deleteExpense = authAction
+  .metadata({ actionName: 'deleteExpense' })
+  .inputSchema(DeleteExpenseSchema)
+  .action(async ({ ctx, parsedInput }) => {
+    await prisma.expense.delete({
+      where: { id: parsedInput.id, organizationId: ctx.session.organizationId! },
+    })
+  })

--- a/src/features/finances/expenses/components/add-expense-button.tsx
+++ b/src/features/finances/expenses/components/add-expense-button.tsx
@@ -1,0 +1,70 @@
+'use client'
+
+import { Button } from '@/src/components/ui/button'
+import {
+  Dialog,
+  DialogClose,
+  DialogContent,
+  DialogDescription,
+  DialogFooter,
+  DialogHeader,
+  DialogTitle,
+  DialogTrigger,
+} from '@/src/components/ui/dialog'
+import { zodResolver } from '@hookform/resolvers/zod'
+import { Loader, Plus } from 'lucide-react'
+import { useState } from 'react'
+import { useForm } from 'react-hook-form'
+import { useExpenseCreateMutation } from '../queries'
+import { CreateExpenseSchema, type CreateExpenseSchemaType } from '../schemas'
+import ExpenseForm from './expense-form'
+
+export default function AddExpenseButton() {
+  const [dialogOpen, setDialogOpen] = useState(false)
+  const createMutation = useExpenseCreateMutation()
+
+  const form = useForm<CreateExpenseSchemaType>({
+    resolver: zodResolver(CreateExpenseSchema),
+    defaultValues: {
+      name: '',
+      amount: undefined,
+      date: undefined,
+      comment: undefined,
+    },
+  })
+
+  const onSubmit = (values: CreateExpenseSchemaType) => {
+    createMutation.mutate(values, {
+      onSuccess: () => {
+        form.reset()
+        setDialogOpen(false)
+      },
+    })
+  }
+
+  return (
+    <Dialog open={dialogOpen} onOpenChange={setDialogOpen}>
+      <DialogTrigger render={<Button size={'icon'} />}>
+        <Plus />
+      </DialogTrigger>
+      <DialogContent>
+        <DialogHeader>
+          <DialogTitle>Добавить расход</DialogTitle>
+          <DialogDescription>Укажите название, сумму и дату расхода</DialogDescription>
+        </DialogHeader>
+        <ExpenseForm form={form} formId="create-expense-form" />
+        <DialogFooter>
+          <DialogClose render={<Button variant="outline" />}>Отмена</DialogClose>
+          <Button
+            type="button"
+            disabled={createMutation.isPending}
+            onClick={form.handleSubmit(onSubmit)}
+          >
+            {createMutation.isPending && <Loader className="animate-spin" />}
+            Создать
+          </Button>
+        </DialogFooter>
+      </DialogContent>
+    </Dialog>
+  )
+}

--- a/src/features/finances/expenses/components/expense-actions.tsx
+++ b/src/features/finances/expenses/components/expense-actions.tsx
@@ -1,0 +1,160 @@
+'use client'
+
+import { Expense } from '@/prisma/generated/client'
+import {
+  AlertDialog,
+  AlertDialogCancel,
+  AlertDialogContent,
+  AlertDialogDescription,
+  AlertDialogFooter,
+  AlertDialogHeader,
+  AlertDialogTitle,
+} from '@/src/components/ui/alert-dialog'
+import { Button } from '@/src/components/ui/button'
+import {
+  Dialog,
+  DialogClose,
+  DialogContent,
+  DialogDescription,
+  DialogFooter,
+  DialogHeader,
+  DialogTitle,
+} from '@/src/components/ui/dialog'
+import {
+  DropdownMenu,
+  DropdownMenuContent,
+  DropdownMenuGroup,
+  DropdownMenuItem,
+  DropdownMenuSeparator,
+  DropdownMenuTrigger,
+} from '@/src/components/ui/dropdown-menu'
+import { zodResolver } from '@hookform/resolvers/zod'
+import { Loader, MoreVertical, Pen, Trash } from 'lucide-react'
+import { useState } from 'react'
+import { useForm } from 'react-hook-form'
+import { useExpenseDeleteMutation, useExpenseUpdateMutation } from '../queries'
+import { UpdateExpenseSchema, type UpdateExpenseSchemaType } from '../schemas'
+import ExpenseForm from './expense-form'
+
+interface ExpenseActionsProps {
+  expense: Expense
+}
+
+export default function ExpenseActions({ expense }: ExpenseActionsProps) {
+  const [open, setOpen] = useState(false)
+  const [confirmOpen, setConfirmOpen] = useState(false)
+  const [editDialogOpen, setEditDialogOpen] = useState(false)
+
+  const updateMutation = useExpenseUpdateMutation()
+  const deleteMutation = useExpenseDeleteMutation()
+
+  const form = useForm<UpdateExpenseSchemaType>({
+    resolver: zodResolver(UpdateExpenseSchema),
+    defaultValues: {
+      id: expense.id,
+      name: expense.name,
+      amount: expense.amount,
+      date:
+        expense.date instanceof Date
+          ? expense.date.toISOString().split('T')[0]
+          : String(expense.date).split('T')[0],
+      comment: expense.comment ?? undefined,
+    },
+  })
+
+  const handleDelete = () => {
+    deleteMutation.mutate(
+      { id: expense.id },
+      {
+        onSuccess: () => setConfirmOpen(false),
+      },
+    )
+  }
+
+  const onSubmit = (values: UpdateExpenseSchemaType) => {
+    updateMutation.mutate(values, {
+      onSuccess: () => {
+        setEditDialogOpen(false)
+        form.reset()
+      },
+    })
+  }
+
+  return (
+    <>
+      <DropdownMenu open={open} onOpenChange={setOpen}>
+        <DropdownMenuTrigger render={<Button variant="ghost" size="icon" />}>
+          <MoreVertical />
+        </DropdownMenuTrigger>
+
+        <DropdownMenuContent className="w-max">
+          <DropdownMenuGroup>
+            <DropdownMenuItem
+              onClick={() => {
+                setEditDialogOpen(true)
+                setOpen(false)
+              }}
+            >
+              <Pen />
+              Редактировать
+            </DropdownMenuItem>
+          </DropdownMenuGroup>
+          <DropdownMenuSeparator />
+          <DropdownMenuItem
+            variant="destructive"
+            onClick={() => {
+              setConfirmOpen(true)
+              setOpen(false)
+            }}
+          >
+            <Trash />
+            Удалить
+          </DropdownMenuItem>
+        </DropdownMenuContent>
+      </DropdownMenu>
+
+      <Dialog open={editDialogOpen} onOpenChange={setEditDialogOpen}>
+        <DialogContent>
+          <DialogHeader>
+            <DialogTitle>Редактировать расход</DialogTitle>
+            <DialogDescription>Изменение расхода &quot;{expense.name}&quot;</DialogDescription>
+          </DialogHeader>
+          <ExpenseForm form={form} formId="edit-expense-form" />
+          <DialogFooter>
+            <DialogClose render={<Button variant="outline" />}>Отмена</DialogClose>
+            <Button
+              type="button"
+              disabled={updateMutation.isPending}
+              onClick={form.handleSubmit(onSubmit)}
+            >
+              {updateMutation.isPending && <Loader className="animate-spin" />}
+              Сохранить
+            </Button>
+          </DialogFooter>
+        </DialogContent>
+      </Dialog>
+
+      <AlertDialog open={confirmOpen} onOpenChange={setConfirmOpen}>
+        <AlertDialogContent>
+          <AlertDialogHeader>
+            <AlertDialogTitle>Удалить расход?</AlertDialogTitle>
+            <AlertDialogDescription>
+              Расход &quot;{expense.name}&quot; будет удалён. Это действие нельзя отменить.
+            </AlertDialogDescription>
+          </AlertDialogHeader>
+          <AlertDialogFooter>
+            <AlertDialogCancel>Отмена</AlertDialogCancel>
+            <Button
+              variant="destructive"
+              disabled={deleteMutation.isPending}
+              onClick={handleDelete}
+            >
+              {deleteMutation.isPending && <Loader className="animate-spin" />}
+              Удалить
+            </Button>
+          </AlertDialogFooter>
+        </AlertDialogContent>
+      </AlertDialog>
+    </>
+  )
+}

--- a/src/features/finances/expenses/components/expense-form.tsx
+++ b/src/features/finances/expenses/components/expense-form.tsx
@@ -1,0 +1,116 @@
+'use client'
+
+import { NumberInput } from '@/src/components/number-input'
+import { Button } from '@/src/components/ui/button'
+import { Calendar } from '@/src/components/ui/calendar'
+import { Field, FieldError, FieldGroup, FieldLabel } from '@/src/components/ui/field'
+import { Input } from '@/src/components/ui/input'
+import { Popover, PopoverContent, PopoverTrigger } from '@/src/components/ui/popover'
+import { normalizeDateOnly } from '@/src/lib/timezone'
+import { format } from 'date-fns'
+import { ru } from 'date-fns/locale'
+import { Calendar as CalendarIcon } from 'lucide-react'
+import { Controller, type FieldValues, type Path, type UseFormReturn } from 'react-hook-form'
+
+interface ExpenseFormProps<T extends FieldValues> {
+  form: UseFormReturn<T>
+  formId: string
+}
+
+export default function ExpenseForm<T extends FieldValues>({ form, formId }: ExpenseFormProps<T>) {
+  return (
+    <form id={formId}>
+      <FieldGroup>
+        {/* Название */}
+        <Controller
+          control={form.control}
+          name={'name' as Path<T>}
+          render={({ field, fieldState }) => (
+            <Field>
+              <FieldLabel htmlFor={`${formId}-name`}>Название</FieldLabel>
+              <Input
+                id={`${formId}-name`}
+                placeholder="Например: Канцелярия, Хозтовары"
+                {...field}
+                value={field.value ?? ''}
+              />
+              {fieldState.invalid && <FieldError errors={[fieldState.error]} />}
+            </Field>
+          )}
+        />
+
+        {/* Сумма */}
+        <Controller
+          control={form.control}
+          name={'amount' as Path<T>}
+          render={({ field, fieldState }) => (
+            <Field>
+              <FieldLabel htmlFor={`${formId}-amount`}>Сумма (₽)</FieldLabel>
+              <NumberInput
+                id={`${formId}-amount`}
+                placeholder="0"
+                {...field}
+                onChange={field.onChange}
+                value={field.value ?? ''}
+                aria-invalid={fieldState.invalid}
+              />
+              {fieldState.invalid && <FieldError errors={[fieldState.error]} />}
+            </Field>
+          )}
+        />
+
+        {/* Дата */}
+        <Controller
+          control={form.control}
+          name={'date' as Path<T>}
+          render={({ field, fieldState }) => (
+            <Field>
+              <FieldLabel>Дата</FieldLabel>
+              <Popover>
+                <PopoverTrigger
+                  render={<Button variant="outline" className="w-full font-normal" />}
+                >
+                  <CalendarIcon className="h-4 w-4" />
+                  {field.value
+                    ? format(new Date(field.value as string), 'd MMM yyyy', { locale: ru })
+                    : 'Выберите дату'}
+                </PopoverTrigger>
+                <PopoverContent className="w-auto p-0" align="start">
+                  <Calendar
+                    mode="single"
+                    selected={field.value ? new Date(field.value as string) : undefined}
+                    onSelect={(value) =>
+                      value && field.onChange(normalizeDateOnly(value).toISOString().split('T')[0])
+                    }
+                    locale={ru}
+                  />
+                </PopoverContent>
+              </Popover>
+              {fieldState.invalid && <FieldError errors={[fieldState.error]} />}
+            </Field>
+          )}
+        />
+
+        {/* Комментарий */}
+        <Controller
+          control={form.control}
+          name={'comment' as Path<T>}
+          render={({ field, fieldState }) => (
+            <Field>
+              <FieldLabel htmlFor={`${formId}-comment`}>
+                Комментарий <span className="text-muted-foreground">(необязательно)</span>
+              </FieldLabel>
+              <Input
+                id={`${formId}-comment`}
+                placeholder="Необязательный комментарий"
+                {...field}
+                value={field.value ?? ''}
+              />
+              {fieldState.invalid && <FieldError errors={[fieldState.error]} />}
+            </Field>
+          )}
+        />
+      </FieldGroup>
+    </form>
+  )
+}

--- a/src/features/finances/expenses/components/expense-table.tsx
+++ b/src/features/finances/expenses/components/expense-table.tsx
@@ -1,0 +1,114 @@
+'use client'
+
+import { Expense } from '@/prisma/generated/client'
+import DataTable from '@/src/components/data-table'
+import { Input } from '@/src/components/ui/input'
+import { Skeleton } from '@/src/components/ui/skeleton'
+import { useTableSearchParams } from '@/src/hooks/use-table-search-params'
+import { formatDateOnly } from '@/src/lib/timezone'
+import {
+  type ColumnDef,
+  getCoreRowModel,
+  getFacetedRowModel,
+  getFacetedUniqueValues,
+  getFilteredRowModel,
+  getPaginationRowModel,
+  getSortedRowModel,
+  useReactTable,
+} from '@tanstack/react-table'
+import { useMemo } from 'react'
+import { useExpenseListQuery } from '../queries'
+import ExpenseActions from './expense-actions'
+
+export default function ExpenseTable() {
+  const { data: expenses = [], isLoading, isError } = useExpenseListQuery()
+
+  const columns: ColumnDef<Expense>[] = useMemo(
+    () => [
+      {
+        header: 'Название',
+        accessorKey: 'name',
+      },
+      {
+        header: 'Сумма',
+        accessorKey: 'amount',
+        cell: ({ row }) => (
+          <span className="tabular-nums">{row.original.amount.toLocaleString('ru-RU')} ₽</span>
+        ),
+      },
+      {
+        header: 'Дата',
+        accessorKey: 'date',
+        cell: ({ row }) => formatDateOnly(row.original.date),
+      },
+      {
+        header: 'Комментарий',
+        accessorKey: 'comment',
+        cell: ({ row }) => row.original.comment || '—',
+      },
+      {
+        id: 'actions',
+        cell: ({ row }) => <ExpenseActions expense={row.original} />,
+      },
+    ],
+    [],
+  )
+
+  const { globalFilter, setGlobalFilter, pagination, setPagination, sorting, setSorting } =
+    useTableSearchParams({
+      search: true,
+      pagination: true,
+      sorting: true,
+    })
+
+  const table = useReactTable({
+    data: expenses,
+    columns,
+    getCoreRowModel: getCoreRowModel(),
+    getFilteredRowModel: getFilteredRowModel(),
+    getFacetedUniqueValues: getFacetedUniqueValues(),
+    getFacetedRowModel: getFacetedRowModel(),
+    globalFilterFn: (row, _columnId, filterValue) => {
+      const searchValue = String(filterValue).toLowerCase()
+      return (
+        row.original.name.toLowerCase().includes(searchValue) ||
+        (row.original.comment?.toLowerCase().includes(searchValue) ?? false)
+      )
+    },
+    onPaginationChange: setPagination,
+    getPaginationRowModel: getPaginationRowModel(),
+    onSortingChange: setSorting,
+    getSortedRowModel: getSortedRowModel(),
+    state: { globalFilter, pagination, sorting },
+  })
+
+  if (isLoading) {
+    return (
+      <div className="flex flex-col gap-3">
+        <Skeleton className="h-9 w-full" />
+        <Skeleton className="h-64 w-full" />
+      </div>
+    )
+  }
+
+  if (isError) {
+    return <div className="text-destructive">Ошибка при загрузке расходов.</div>
+  }
+
+  return (
+    <DataTable
+      table={table}
+      emptyMessage="Нет расходов."
+      showPagination
+      toolbar={
+        <div className="flex flex-col items-end gap-2 md:flex-row">
+          <Input
+            value={globalFilter}
+            onChange={(e) => setGlobalFilter(e.target.value)}
+            placeholder="Поиск..."
+          />
+        </div>
+      }
+    />
+  )
+}

--- a/src/features/finances/expenses/queries.ts
+++ b/src/features/finances/expenses/queries.ts
@@ -1,0 +1,71 @@
+import { useMutation, useQuery, useQueryClient } from '@tanstack/react-query'
+import { toast } from 'sonner'
+import { createExpense, deleteExpense, getExpenses, updateExpense } from './actions'
+import type {
+  CreateExpenseSchemaType,
+  DeleteExpenseSchemaType,
+  UpdateExpenseSchemaType,
+} from './schemas'
+
+export const expenseKeys = {
+  all: ['expenses'] as const,
+}
+
+export const useExpenseListQuery = () => {
+  return useQuery({
+    queryKey: expenseKeys.all,
+    queryFn: async () => {
+      const { data, serverError } = await getExpenses()
+      if (serverError) throw serverError
+      return data ?? []
+    },
+  })
+}
+
+export const useExpenseCreateMutation = () => {
+  const queryClient = useQueryClient()
+  return useMutation({
+    mutationFn: async (values: CreateExpenseSchemaType) => {
+      const { data, serverError } = await createExpense(values)
+      if (serverError) throw serverError
+      return data
+    },
+    onSuccess: () => {
+      queryClient.invalidateQueries({ queryKey: expenseKeys.all })
+      toast.success('Расход успешно добавлен!')
+    },
+    onError: () => toast.error('Ошибка при добавлении расхода.'),
+  })
+}
+
+export const useExpenseUpdateMutation = () => {
+  const queryClient = useQueryClient()
+  return useMutation({
+    mutationFn: async (values: UpdateExpenseSchemaType) => {
+      const { data, serverError } = await updateExpense(values)
+      if (serverError) throw serverError
+      return data
+    },
+    onSuccess: () => {
+      queryClient.invalidateQueries({ queryKey: expenseKeys.all })
+      toast.success('Расход успешно обновлён!')
+    },
+    onError: () => toast.error('Ошибка при обновлении расхода.'),
+  })
+}
+
+export const useExpenseDeleteMutation = () => {
+  const queryClient = useQueryClient()
+  return useMutation({
+    mutationFn: async (values: DeleteExpenseSchemaType) => {
+      const { data, serverError } = await deleteExpense(values)
+      if (serverError) throw serverError
+      return data
+    },
+    onSuccess: () => {
+      queryClient.invalidateQueries({ queryKey: expenseKeys.all })
+      toast.success('Расход успешно удалён!')
+    },
+    onError: () => toast.error('Не удалось удалить расход.'),
+  })
+}

--- a/src/features/finances/expenses/schemas.ts
+++ b/src/features/finances/expenses/schemas.ts
@@ -1,0 +1,25 @@
+import * as z from 'zod'
+
+export const ExpenseBaseSchema = z.object({
+  name: z
+    .string('Введите название')
+    .min(1, 'Название обязательно')
+    .max(100, 'Название не должно превышать 100 символов'),
+  amount: z.int('Укажите сумму').positive('Сумма должна быть больше 0'),
+  date: z.string('Укажите дату'),
+  comment: z.string().max(200, 'Комментарий не должен превышать 200 символов').optional(),
+})
+
+export const CreateExpenseSchema = ExpenseBaseSchema
+
+export const UpdateExpenseSchema = ExpenseBaseSchema.partial().extend({
+  id: z.int().positive(),
+})
+
+export const DeleteExpenseSchema = z.object({
+  id: z.int().positive(),
+})
+
+export type CreateExpenseSchemaType = z.infer<typeof CreateExpenseSchema>
+export type UpdateExpenseSchemaType = z.infer<typeof UpdateExpenseSchema>
+export type DeleteExpenseSchemaType = z.infer<typeof DeleteExpenseSchema>

--- a/src/features/finances/profit/actions.ts
+++ b/src/features/finances/profit/actions.ts
@@ -1,0 +1,269 @@
+'use server'
+
+import {
+  TAX_SYSTEM_CONFIG_SCHEMAS,
+  TAX_SYSTEMS,
+  type TaxSystemKey,
+  type UsnIncomeConfig,
+} from '@/src/features/organization/tax-systems/schemas'
+import prisma from '@/src/lib/db/prisma'
+import { authAction } from '@/src/lib/safe-action'
+import { DEFAULT_CHARGEABLE_STATUSES } from '../chargeable'
+import { computeAttendanceRevenue } from '../chargeable.server'
+import { ProfitFiltersSchema } from './schemas'
+import type {
+  AcquiringBreakdownItem,
+  AcquiringData,
+  ExpenseBreakdownItem,
+  ExpenseData,
+  ProfitData,
+  RentBreakdownItem,
+  RentData,
+  SalaryData,
+  TaxBreakdown,
+} from './types'
+
+export const getProfitData = authAction
+  .metadata({ actionName: 'getProfitData' })
+  .inputSchema(ProfitFiltersSchema)
+  .action(async ({ ctx, parsedInput }): Promise<ProfitData> => {
+    const { startDate, endDate } = parsedInput
+    const organizationId = ctx.session.organizationId!
+
+    // ── 1. Revenue ──────────────────────────────────────────────────────────
+    const revenueEntries = await computeAttendanceRevenue({
+      organizationId,
+      startDate,
+      endDate,
+      chargeableStatuses: [...DEFAULT_CHARGEABLE_STATUSES],
+    })
+    const revenue = revenueEntries.reduce((sum, e) => sum + e.visitCost, 0)
+
+    // ── 2. Taxes ────────────────────────────────────────────────────────────
+    const taxConfig = await prisma.taxConfig.findUnique({
+      where: { organizationId },
+    })
+
+    let taxBreakdown: TaxBreakdown
+    let taxTotal: number
+
+    const taxSystem = (taxConfig?.taxSystem ?? 'USN_INCOME') as TaxSystemKey
+    const taxSystemMeta = TAX_SYSTEMS.find((s) => s.value === taxSystem)
+    const taxSystemLabel = taxSystemMeta?.label ?? taxSystem
+
+    if (taxSystem === 'USN_INCOME') {
+      const schema = TAX_SYSTEM_CONFIG_SCHEMAS.USN_INCOME
+      const config = schema.parse(
+        (taxConfig?.config as Record<string, unknown>) ?? {},
+      ) as UsnIncomeConfig
+
+      const incomeTax = revenue * (config.incomeTaxRate / 100)
+
+      // Insurance: 1% from revenue exceeding threshold
+      const excessIncome = Math.max(0, revenue - config.insuranceThreshold)
+      const insuranceContributions = excessIncome * (config.insuranceRate / 100)
+
+      taxTotal = incomeTax + insuranceContributions + config.fixedContributions
+      taxBreakdown = {
+        taxSystem,
+        taxSystemLabel,
+        incomeTax: Math.round(incomeTax),
+        incomeTaxRate: config.incomeTaxRate,
+        insuranceContributions: Math.round(insuranceContributions),
+        fixedContributions: config.fixedContributions,
+      }
+    } else {
+      // Fallback for other tax systems — just show zero with label
+      taxTotal = 0
+      taxBreakdown = {
+        taxSystem,
+        taxSystemLabel,
+        incomeTax: 0,
+        incomeTaxRate: 0,
+        insuranceContributions: 0,
+        fixedContributions: 0,
+      }
+    }
+
+    // ── 3. Acquiring fees ───────────────────────────────────────────────────
+    const payments = await prisma.payment.findMany({
+      where: {
+        organizationId,
+        date: { gte: startDate, lte: endDate },
+      },
+      select: {
+        price: true,
+        paymentMethod: {
+          select: {
+            id: true,
+            name: true,
+            commission: true,
+          },
+        },
+      },
+    })
+
+    // Group by payment method
+    const methodMap = new Map<number, { name: string; commission: number; totalPayments: number }>()
+
+    for (const payment of payments) {
+      if (!payment.paymentMethod) continue
+      const { id, name, commission } = payment.paymentMethod
+      const existing = methodMap.get(id)
+      if (existing) {
+        existing.totalPayments += payment.price
+      } else {
+        methodMap.set(id, { name, commission, totalPayments: payment.price })
+      }
+    }
+
+    const acquiringBreakdown: AcquiringBreakdownItem[] = []
+    let acquiringTotal = 0
+
+    for (const [, method] of methodMap) {
+      const fee = method.totalPayments * (method.commission / 100)
+      acquiringTotal += fee
+      acquiringBreakdown.push({
+        methodName: method.name,
+        commissionPercent: method.commission,
+        paymentSum: method.totalPayments,
+        fee: Math.round(fee),
+      })
+    }
+
+    const acquiring: AcquiringData = {
+      total: Math.round(acquiringTotal),
+      breakdown: acquiringBreakdown,
+    }
+
+    // ── 4. Salaries ─────────────────────────────────────────────────────────
+    const lessons = await prisma.lesson.findMany({
+      where: {
+        organizationId,
+        date: { gte: startDate, lte: endDate },
+        status: { not: 'CANCELLED' },
+      },
+      select: {
+        teachers: {
+          select: {
+            bid: true,
+            bonusPerStudent: true,
+            teacherId: true,
+          },
+        },
+        _count: { select: { attendance: { where: { status: 'PRESENT' } } } },
+      },
+    })
+
+    const teacherIds = new Set<number>()
+    let totalFromLessons = 0
+    let lessonCount = 0
+
+    for (const lesson of lessons) {
+      for (const tl of lesson.teachers) {
+        teacherIds.add(tl.teacherId)
+        const bonusTotal = tl.bonusPerStudent * (lesson._count?.attendance ?? 0)
+        totalFromLessons += tl.bid + bonusTotal
+      }
+      lessonCount++
+    }
+
+    const paychecks = await prisma.payCheck.findMany({
+      where: {
+        organizationId,
+        date: { gte: startDate, lte: endDate },
+      },
+      select: { amount: true },
+    })
+
+    const totalFromPaychecks = paychecks.reduce((sum, p) => sum + p.amount, 0)
+
+    const salaries: SalaryData = {
+      total: totalFromLessons + totalFromPaychecks,
+      totalFromLessons,
+      totalFromPaychecks,
+      teacherCount: teacherIds.size,
+      lessonCount,
+    }
+
+    // ── 5. Rent ─────────────────────────────────────────────────────────────
+    const rents = await prisma.rent.findMany({
+      where: {
+        organizationId,
+        AND: [{ startDate: { lte: endDate } }, { endDate: { gte: startDate } }],
+      },
+      select: {
+        amount: true,
+        location: {
+          select: { name: true },
+        },
+      },
+    })
+
+    const rentLocationMap = new Map<string, number>()
+    let rentTotal = 0
+
+    for (const r of rents) {
+      const locationName = r.location.name
+      rentLocationMap.set(locationName, (rentLocationMap.get(locationName) ?? 0) + r.amount)
+      rentTotal += r.amount
+    }
+
+    const rentBreakdown: RentBreakdownItem[] = []
+    for (const [locationName, amount] of rentLocationMap) {
+      rentBreakdown.push({ locationName, amount })
+    }
+
+    const rent: RentData = {
+      total: rentTotal,
+      breakdown: rentBreakdown,
+    }
+
+    // ── 6. Other expenses ───────────────────────────────────────────────────
+    const expensesRaw = await prisma.expense.findMany({
+      where: {
+        organizationId,
+        date: { gte: startDate, lte: endDate },
+      },
+      select: {
+        name: true,
+        amount: true,
+      },
+    })
+
+    const expenseNameMap = new Map<string, number>()
+    let expenseTotal = 0
+
+    for (const e of expensesRaw) {
+      expenseNameMap.set(e.name, (expenseNameMap.get(e.name) ?? 0) + e.amount)
+      expenseTotal += e.amount
+    }
+
+    const expenseBreakdown: ExpenseBreakdownItem[] = []
+    for (const [name, amount] of expenseNameMap) {
+      expenseBreakdown.push({ name, amount })
+    }
+
+    const expenses: ExpenseData = {
+      total: expenseTotal,
+      breakdown: expenseBreakdown,
+    }
+
+    // ── 7. Profit ───────────────────────────────────────────────────────────
+    const profit = Math.round(
+      revenue - taxTotal - acquiring.total - salaries.total - rent.total - expenses.total,
+    )
+
+    return {
+      revenue: Math.round(revenue),
+      taxes: {
+        total: Math.round(taxTotal),
+        breakdown: taxBreakdown,
+      },
+      acquiring,
+      salaries,
+      rent,
+      expenses,
+      profit,
+    }
+  })

--- a/src/features/finances/profit/components/profit-breakdown.tsx
+++ b/src/features/finances/profit/components/profit-breakdown.tsx
@@ -1,0 +1,344 @@
+'use client'
+
+import { Hint } from '@/src/components/hint'
+import {
+  Accordion,
+  AccordionContent,
+  AccordionItem,
+  AccordionTrigger,
+} from '@/src/components/ui/accordion'
+import { Badge } from '@/src/components/ui/badge'
+import { Card, CardContent, CardHeader, CardTitle } from '@/src/components/ui/card'
+import { Building2, CreditCard, Landmark, Receipt, Users } from 'lucide-react'
+import type { ProfitData } from '../types'
+
+function formatCurrency(value: number) {
+  return new Intl.NumberFormat('ru-RU', {
+    style: 'currency',
+    currency: 'RUB',
+    maximumFractionDigits: 0,
+  }).format(value)
+}
+
+function pct(part: number, total: number) {
+  if (total === 0) return '0%'
+  return `${((part / total) * 100).toFixed(1)}%`
+}
+
+interface ProfitBreakdownProps {
+  data: ProfitData
+}
+
+export default function ProfitBreakdown({ data }: ProfitBreakdownProps) {
+  const { revenue, taxes, acquiring, salaries, rent, expenses } = data
+
+  return (
+    <Card>
+      <CardHeader>
+        <CardTitle className="flex items-center gap-2 text-sm">
+          Детализация расходов
+          <Hint text="Подробная разбивка всех расходов за выбранный период" />
+        </CardTitle>
+      </CardHeader>
+      <CardContent className="p-0 pb-2 sm:px-4">
+        {/* Waterfall bar */}
+        <div className="mb-4 px-4 sm:px-0">
+          <WaterfallBar data={data} />
+        </div>
+
+        <Accordion>
+          {/* Taxes */}
+          <AccordionItem>
+            <AccordionTrigger>
+              <div className="flex items-center gap-2">
+                <Landmark className="text-muted-foreground size-4" />
+                <span>Налоги</span>
+                <Badge variant="outline" className="text-[0.625rem]">
+                  {taxes.breakdown.taxSystemLabel}
+                </Badge>
+              </div>
+              <span className="text-muted-foreground mr-6 font-mono text-xs">
+                {formatCurrency(taxes.total)}
+              </span>
+            </AccordionTrigger>
+            <AccordionContent>
+              <div className="space-y-2">
+                <DetailRow
+                  label={`Налог на доход (${taxes.breakdown.incomeTaxRate}%)`}
+                  value={formatCurrency(taxes.breakdown.incomeTax)}
+                  hint={`${pct(taxes.breakdown.incomeTax, revenue)} от выручки`}
+                />
+                <DetailRow
+                  label="Страховые взносы (сверх порога)"
+                  value={formatCurrency(taxes.breakdown.insuranceContributions)}
+                  hint="1% от дохода, превышающего порог"
+                />
+                <DetailRow
+                  label="Фиксированные взносы"
+                  value={formatCurrency(taxes.breakdown.fixedContributions)}
+                  hint="Обязательные страховые взносы за период"
+                />
+                <div className="border-t pt-2">
+                  <DetailRow label="Итого налоги" value={formatCurrency(taxes.total)} bold />
+                </div>
+              </div>
+            </AccordionContent>
+          </AccordionItem>
+
+          {/* Acquiring */}
+          <AccordionItem>
+            <AccordionTrigger>
+              <div className="flex items-center gap-2">
+                <CreditCard className="text-muted-foreground size-4" />
+                <span>Эквайринг</span>
+                <Badge variant="outline" className="text-[0.625rem]">
+                  {acquiring.breakdown.length} мет.
+                </Badge>
+              </div>
+              <span className="text-muted-foreground mr-6 font-mono text-xs">
+                {formatCurrency(acquiring.total)}
+              </span>
+            </AccordionTrigger>
+            <AccordionContent>
+              <div className="space-y-2">
+                {acquiring.breakdown.length === 0 ? (
+                  <p className="text-muted-foreground text-xs">
+                    Нет оплат с комиссией за выбранный период
+                  </p>
+                ) : (
+                  <>
+                    {acquiring.breakdown.map((item) => (
+                      <DetailRow
+                        key={item.methodName}
+                        label={`${item.methodName} (${item.commissionPercent}%)`}
+                        value={formatCurrency(item.fee)}
+                        hint={`Оплат на ${formatCurrency(item.paymentSum)} × ${item.commissionPercent}%`}
+                      />
+                    ))}
+                    <div className="border-t pt-2">
+                      <DetailRow
+                        label="Итого эквайринг"
+                        value={formatCurrency(acquiring.total)}
+                        bold
+                      />
+                    </div>
+                  </>
+                )}
+              </div>
+            </AccordionContent>
+          </AccordionItem>
+
+          {/* Salaries */}
+          <AccordionItem>
+            <AccordionTrigger>
+              <div className="flex items-center gap-2">
+                <Users className="text-muted-foreground size-4" />
+                <span>Зарплаты</span>
+                <Badge variant="outline" className="text-[0.625rem]">
+                  {salaries.teacherCount} преп.
+                </Badge>
+              </div>
+              <span className="text-muted-foreground mr-6 font-mono text-xs">
+                {formatCurrency(salaries.total)}
+              </span>
+            </AccordionTrigger>
+            <AccordionContent>
+              <div className="space-y-2">
+                <DetailRow
+                  label="Оплата за уроки"
+                  value={formatCurrency(salaries.totalFromLessons)}
+                  hint={`${salaries.lessonCount} уроков. Формула: ставка + бонус за ученика × кол-во присутствующих`}
+                />
+                <DetailRow
+                  label="Начисления (aвансы, бонусы)"
+                  value={formatCurrency(salaries.totalFromPaychecks)}
+                  hint="Дополнительные выплаты, зафиксированные в системе"
+                />
+                <div className="border-t pt-2">
+                  <DetailRow label="Итого зарплаты" value={formatCurrency(salaries.total)} bold />
+                </div>
+              </div>
+            </AccordionContent>
+          </AccordionItem>
+
+          {/* Rent */}
+          <AccordionItem>
+            <AccordionTrigger>
+              <div className="flex items-center gap-2">
+                <Building2 className="text-muted-foreground size-4" />
+                <span>Аренда</span>
+                <Badge variant="outline" className="text-[0.625rem]">
+                  {rent.breakdown.length} лок.
+                </Badge>
+              </div>
+              <span className="text-muted-foreground mr-6 font-mono text-xs">
+                {formatCurrency(rent.total)}
+              </span>
+            </AccordionTrigger>
+            <AccordionContent>
+              <div className="space-y-2">
+                {rent.breakdown.length === 0 ? (
+                  <p className="text-muted-foreground text-xs">
+                    Нет расходов на аренду за выбранный период
+                  </p>
+                ) : (
+                  <>
+                    {rent.breakdown.map((item) => (
+                      <DetailRow
+                        key={item.locationName}
+                        label={item.locationName}
+                        value={formatCurrency(item.amount)}
+                        hint={`${pct(item.amount, rent.total)} от общей аренды`}
+                      />
+                    ))}
+                    <div className="border-t pt-2">
+                      <DetailRow label="Итого аренда" value={formatCurrency(rent.total)} bold />
+                    </div>
+                  </>
+                )}
+              </div>
+            </AccordionContent>
+          </AccordionItem>
+
+          {/* Other expenses */}
+          <AccordionItem>
+            <AccordionTrigger>
+              <div className="flex items-center gap-2">
+                <Receipt className="text-muted-foreground size-4" />
+                <span>Прочие расходы</span>
+                <Badge variant="outline" className="text-[0.625rem]">
+                  {expenses.breakdown.length} позиц.
+                </Badge>
+              </div>
+              <span className="text-muted-foreground mr-6 font-mono text-xs">
+                {formatCurrency(expenses.total)}
+              </span>
+            </AccordionTrigger>
+            <AccordionContent>
+              <div className="space-y-2">
+                {expenses.breakdown.length === 0 ? (
+                  <p className="text-muted-foreground text-xs">
+                    Нет прочих расходов за выбранный период
+                  </p>
+                ) : (
+                  <>
+                    {expenses.breakdown.map((item) => (
+                      <DetailRow
+                        key={item.name}
+                        label={item.name}
+                        value={formatCurrency(item.amount)}
+                        hint={`${pct(item.amount, expenses.total)} от прочих расходов`}
+                      />
+                    ))}
+                    <div className="border-t pt-2">
+                      <DetailRow
+                        label="Итого прочие расходы"
+                        value={formatCurrency(expenses.total)}
+                        bold
+                      />
+                    </div>
+                  </>
+                )}
+              </div>
+            </AccordionContent>
+          </AccordionItem>
+        </Accordion>
+      </CardContent>
+    </Card>
+  )
+}
+
+// ── Detail Row ────────────────────────────────────────────────────────────────
+
+function DetailRow({
+  label,
+  value,
+  hint,
+  bold,
+}: {
+  label: string
+  value: string
+  hint?: string
+  bold?: boolean
+}) {
+  return (
+    <div className="flex items-center justify-between gap-4">
+      <span
+        className={`flex items-center gap-1 text-xs ${bold ? 'font-semibold' : 'text-muted-foreground'}`}
+      >
+        {label}
+        {hint && <Hint text={hint} />}
+      </span>
+      <span className={`font-mono text-xs ${bold ? 'font-semibold' : ''}`}>{value}</span>
+    </div>
+  )
+}
+
+// ── Waterfall Bar ─────────────────────────────────────────────────────────────
+
+function WaterfallBar({ data }: { data: ProfitData }) {
+  const { revenue, taxes, acquiring, salaries, rent, expenses } = data
+  if (revenue === 0) return null
+
+  const items = [
+    { label: 'Налоги', value: taxes.total, color: 'bg-amber-400 dark:bg-amber-500' },
+    { label: 'Эквайринг', value: acquiring.total, color: 'bg-blue-400 dark:bg-blue-500' },
+    { label: 'Зарплаты', value: salaries.total, color: 'bg-purple-400 dark:bg-purple-500' },
+    { label: 'Аренда', value: rent.total, color: 'bg-orange-400 dark:bg-orange-500' },
+    { label: 'Прочее', value: expenses.total, color: 'bg-gray-400 dark:bg-gray-500' },
+  ]
+
+  const totalExpenses = items.reduce((s, i) => s + i.value, 0)
+  const profitRatio = Math.max(0, (revenue - totalExpenses) / revenue)
+
+  return (
+    <div className="space-y-2">
+      <div className="flex items-center justify-between text-[0.625rem]">
+        <span className="text-muted-foreground">Структура расходов</span>
+        <span className="text-muted-foreground">
+          {pct(totalExpenses, revenue)} расходы ·{' '}
+          {pct(Math.max(0, revenue - totalExpenses), revenue)} прибыль
+        </span>
+      </div>
+
+      <div className="bg-muted flex h-3 overflow-hidden rounded-full">
+        {items.map(
+          (item) =>
+            item.value > 0 && (
+              <div
+                key={item.label}
+                className={`${item.color} transition-all`}
+                style={{ width: `${(item.value / revenue) * 100}%` }}
+                title={`${item.label}: ${formatCurrency(item.value)} (${pct(item.value, revenue)})`}
+              />
+            ),
+        )}
+        {profitRatio > 0 && (
+          <div
+            className="bg-emerald-400 transition-all dark:bg-emerald-500"
+            style={{ width: `${profitRatio * 100}%` }}
+            title={`Прибыль: ${formatCurrency(revenue - totalExpenses)} (${pct(revenue - totalExpenses, revenue)})`}
+          />
+        )}
+      </div>
+
+      {/* Legend */}
+      <div className="flex flex-wrap gap-x-3 gap-y-1">
+        {items
+          .filter((i) => i.value > 0)
+          .map((item) => (
+            <div key={item.label} className="flex items-center gap-1">
+              <div className={`size-2 rounded-full ${item.color}`} />
+              <span className="text-muted-foreground text-[0.5625rem]">{item.label}</span>
+            </div>
+          ))}
+        {profitRatio > 0 && (
+          <div className="flex items-center gap-1">
+            <div className="size-2 rounded-full bg-emerald-400 dark:bg-emerald-500" />
+            <span className="text-muted-foreground text-[0.5625rem]">Прибыль</span>
+          </div>
+        )}
+      </div>
+    </div>
+  )
+}

--- a/src/features/finances/profit/components/profit-summary.tsx
+++ b/src/features/finances/profit/components/profit-summary.tsx
@@ -1,0 +1,107 @@
+'use client'
+
+import { StatCard } from '@/src/components/stat-card'
+import {
+  Banknote,
+  Building2,
+  CreditCard,
+  Landmark,
+  Receipt,
+  TrendingDown,
+  TrendingUp,
+  Users,
+} from 'lucide-react'
+import type { ProfitData } from '../types'
+
+function formatCurrency(value: number) {
+  return new Intl.NumberFormat('ru-RU', {
+    style: 'currency',
+    currency: 'RUB',
+    maximumFractionDigits: 0,
+  }).format(value)
+}
+
+function pct(part: number, total: number) {
+  if (total === 0) return '0%'
+  return `${((part / total) * 100).toFixed(1)}%`
+}
+
+interface ProfitSummaryProps {
+  data: ProfitData
+}
+
+export default function ProfitSummary({ data }: ProfitSummaryProps) {
+  const { revenue, taxes, acquiring, salaries, rent, expenses, profit } = data
+  const isPositive = profit >= 0
+
+  return (
+    <div className="space-y-2">
+      {/* Revenue */}
+      <div className="grid grid-cols-1 gap-2">
+        <StatCard
+          label="Выручка за период"
+          value={formatCurrency(revenue)}
+          icon={Banknote}
+          variant="default"
+          hint="Сумма стоимости всех платных посещений за период. Рассчитывается как: оплата ученика / кол-во уроков в кошельке × кол-во посещений"
+        />
+      </div>
+
+      {/* Expenses */}
+      <div className="grid grid-cols-2 gap-2 sm:grid-cols-5">
+        <StatCard
+          label="Налоги"
+          value={formatCurrency(taxes.total)}
+          description={`${pct(taxes.total, revenue)} от выручки · ${taxes.breakdown.taxSystemLabel}`}
+          icon={Landmark}
+          variant="default"
+          hint={`Рассчитано по системе «${taxes.breakdown.taxSystemLabel}». Налог на доход: ${formatCurrency(taxes.breakdown.incomeTax)} (${taxes.breakdown.incomeTaxRate}%). Страховые: ${formatCurrency(taxes.breakdown.insuranceContributions)}. Фиксированные взносы: ${formatCurrency(taxes.breakdown.fixedContributions)}`}
+        />
+        <StatCard
+          label="Эквайринг"
+          value={formatCurrency(acquiring.total)}
+          description={`${pct(acquiring.total, revenue)} от выручки · ${acquiring.breakdown.length} мет. оплаты`}
+          icon={CreditCard}
+          variant="default"
+          hint="Комиссии платёжных систем. Рассчитывается для каждого метода оплаты как: сумма оплат × комиссия %"
+        />
+        <StatCard
+          label="Зарплаты"
+          value={formatCurrency(salaries.total)}
+          description={`${pct(salaries.total, revenue)} от выручки · ${salaries.teacherCount} преп.`}
+          icon={Users}
+          variant="default"
+          hint={`Общая сумма зарплат за период. Из уроков: ${formatCurrency(salaries.totalFromLessons)} (${salaries.lessonCount} ур.). Из начислений: ${formatCurrency(salaries.totalFromPaychecks)}`}
+        />
+        <StatCard
+          label="Аренда"
+          value={formatCurrency(rent.total)}
+          description={`${pct(rent.total, revenue)} от выручки · ${rent.breakdown.length} лок.`}
+          icon={Building2}
+          variant="default"
+          hint={`Аренда помещений за период. ${rent.breakdown.map((r) => `${r.locationName}: ${formatCurrency(r.amount)}`).join(', ') || 'Нет данных'}`}
+        />
+        <StatCard
+          label="Прочие расходы"
+          value={formatCurrency(expenses.total)}
+          description={`${pct(expenses.total, revenue)} от выручки · ${expenses.breakdown.length} позиц.`}
+          icon={Receipt}
+          variant="default"
+          hint={`Прочие операционные расходы. ${expenses.breakdown.map((e) => `${e.name}: ${formatCurrency(e.amount)}`).join(', ') || 'Нет данных'}`}
+        />
+      </div>
+
+      {/* Profit - highlighted */}
+      <div className="grid grid-cols-1 gap-2">
+        <StatCard
+          label="Чистая прибыль"
+          value={formatCurrency(profit)}
+          description={`${pct(Math.abs(profit), revenue)} от выручки`}
+          icon={isPositive ? TrendingUp : TrendingDown}
+          variant={isPositive ? 'success' : 'danger'}
+          hint="Прибыль = Выручка − Налоги − Эквайринг − Зарплаты − Аренда − Прочие расходы"
+        />
+      </div>
+    </div>
+  )
+}

--- a/src/features/finances/profit/components/profit.tsx
+++ b/src/features/finances/profit/components/profit.tsx
@@ -1,0 +1,218 @@
+'use client'
+
+import { Button } from '@/src/components/ui/button'
+import { Calendar } from '@/src/components/ui/calendar'
+import { Card, CardContent } from '@/src/components/ui/card'
+import {
+  Empty,
+  EmptyDescription,
+  EmptyHeader,
+  EmptyMedia,
+  EmptyTitle,
+} from '@/src/components/ui/empty'
+import { Popover, PopoverContent, PopoverTrigger } from '@/src/components/ui/popover'
+import { Skeleton } from '@/src/components/ui/skeleton'
+import { moscowNow, normalizeDateOnly } from '@/src/lib/timezone'
+import {
+  endOfMonth,
+  endOfQuarter,
+  endOfWeek,
+  format,
+  startOfMonth,
+  startOfQuarter,
+  startOfWeek,
+  subMonths,
+  subQuarters,
+  subWeeks,
+} from 'date-fns'
+import { ru } from 'date-fns/locale'
+import { Calendar as CalendarIcon, CalendarSearch, ChevronDown, X } from 'lucide-react'
+import { useMemo, useState } from 'react'
+import type { DateRange } from 'react-day-picker'
+import { useProfitDataQuery } from '../queries'
+import type { ProfitFilters } from '../schemas'
+import ProfitBreakdown from './profit-breakdown'
+import ProfitSummary from './profit-summary'
+
+const datePresets = [
+  {
+    label: 'Текущая неделя',
+    getValue: () => ({
+      from: startOfWeek(moscowNow(), { weekStartsOn: 1 }),
+      to: endOfWeek(moscowNow(), { weekStartsOn: 1 }),
+    }),
+  },
+  {
+    label: 'Прошлая неделя',
+    getValue: () => ({
+      from: startOfWeek(subWeeks(moscowNow(), 1), { weekStartsOn: 1 }),
+      to: endOfWeek(subWeeks(moscowNow(), 1), { weekStartsOn: 1 }),
+    }),
+  },
+  {
+    label: 'Текущий месяц',
+    getValue: () => ({
+      from: startOfMonth(moscowNow()),
+      to: endOfMonth(moscowNow()),
+    }),
+  },
+  {
+    label: 'Прошлый месяц',
+    getValue: () => ({
+      from: startOfMonth(subMonths(moscowNow(), 1)),
+      to: endOfMonth(subMonths(moscowNow(), 1)),
+    }),
+  },
+  {
+    label: 'Текущий квартал',
+    getValue: () => ({
+      from: startOfQuarter(moscowNow()),
+      to: endOfQuarter(moscowNow()),
+    }),
+  },
+  {
+    label: 'Прошлый квартал',
+    getValue: () => ({
+      from: startOfQuarter(subQuarters(moscowNow(), 1)),
+      to: endOfQuarter(subQuarters(moscowNow(), 1)),
+    }),
+  },
+]
+
+export default function Profit() {
+  const [dateRange, setDateRange] = useState<DateRange | undefined>(undefined)
+  const [isCalendarOpen, setIsCalendarOpen] = useState(false)
+
+  const filters: ProfitFilters | null = useMemo(() => {
+    if (!dateRange?.from || !dateRange?.to) return null
+    return {
+      startDate: normalizeDateOnly(dateRange.from).toISOString(),
+      endDate: normalizeDateOnly(dateRange.to).toISOString(),
+    }
+  }, [dateRange])
+
+  const { data, isPending, isError, error } = useProfitDataQuery(filters)
+  const isLoading = isPending && !!filters
+
+  const handlePresetSelect = (preset: (typeof datePresets)[0]) => {
+    setDateRange(preset.getValue())
+    setIsCalendarOpen(false)
+  }
+
+  const formatDateRange = () => {
+    if (!dateRange?.from) return 'Выберите период'
+    if (!dateRange.to) return format(dateRange.from, 'd MMM yyyy', { locale: ru })
+    return `${format(dateRange.from, 'd MMM', { locale: ru })} – ${format(dateRange.to, 'd MMM yyyy', { locale: ru })}`
+  }
+
+  return (
+    <>
+      {/* Date range picker */}
+      <Card>
+        <CardContent>
+          <div className="flex items-center gap-2">
+            <Popover open={isCalendarOpen} onOpenChange={setIsCalendarOpen}>
+              <PopoverTrigger
+                render={
+                  <Button variant="outline" className="min-w-50 justify-start gap-2">
+                    <CalendarIcon className="h-4 w-4" />
+                    <span className="truncate">{formatDateRange()}</span>
+                    <ChevronDown className="ml-auto h-4 w-4 opacity-50" />
+                  </Button>
+                }
+              />
+              <PopoverContent className="w-auto p-0" align="start">
+                <div className="flex">
+                  {/* Presets */}
+                  <div className="border-r p-2">
+                    <div className="text-muted-foreground mb-2 px-2 text-xs font-medium">
+                      Быстрый выбор
+                    </div>
+                    <div className="flex flex-col gap-1">
+                      {datePresets.map((preset) => (
+                        <Button
+                          key={preset.label}
+                          variant="ghost"
+                          className="justify-start text-xs"
+                          onClick={() => handlePresetSelect(preset)}
+                        >
+                          {preset.label}
+                        </Button>
+                      ))}
+                    </div>
+                  </div>
+                  {/* Calendar */}
+                  <Calendar
+                    mode="range"
+                    defaultMonth={dateRange?.from}
+                    selected={dateRange}
+                    onSelect={setDateRange}
+                    locale={ru}
+                    numberOfMonths={2}
+                  />
+                </div>
+              </PopoverContent>
+            </Popover>
+
+            {dateRange && (
+              <Button variant="ghost" size="icon" onClick={() => setDateRange(undefined)}>
+                <X className="h-4 w-4" />
+              </Button>
+            )}
+          </div>
+        </CardContent>
+      </Card>
+
+      {/* Empty state */}
+      {!filters && (
+        <Empty className="bg-card ring-foreground/10 h-full ring-1">
+          <EmptyHeader>
+            <EmptyMedia variant="icon">
+              <CalendarSearch />
+            </EmptyMedia>
+            <EmptyTitle>Период не выбран</EmptyTitle>
+            <EmptyDescription>
+              Укажите диапазон дат, чтобы рассчитать прибыль за период
+            </EmptyDescription>
+          </EmptyHeader>
+        </Empty>
+      )}
+
+      {/* Error state */}
+      {isError && !isLoading && (
+        <Empty className="bg-card ring-destructive/20 h-full ring-1">
+          <EmptyHeader>
+            <EmptyTitle>Ошибка загрузки</EmptyTitle>
+            <EmptyDescription>
+              {error instanceof Error ? error.message : 'Не удалось загрузить данные'}
+            </EmptyDescription>
+          </EmptyHeader>
+        </Empty>
+      )}
+
+      {/* Loading state */}
+      {isLoading && (
+        <div className="space-y-2">
+          <div className="grid grid-cols-2 gap-2 sm:grid-cols-3 lg:grid-cols-6">
+            {Array.from({ length: 6 }).map((_, i) => (
+              <Skeleton key={i} className="h-24 rounded-lg" />
+            ))}
+          </div>
+          <Skeleton className="h-80 rounded-lg" />
+        </div>
+      )}
+
+      {/* Data loaded */}
+      {data && !isLoading && (
+        <Card>
+          <CardContent>
+            <div className="space-y-4">
+              <ProfitSummary data={data} />
+              <ProfitBreakdown data={data} />
+            </div>
+          </CardContent>
+        </Card>
+      )}
+    </>
+  )
+}

--- a/src/features/finances/profit/queries.ts
+++ b/src/features/finances/profit/queries.ts
@@ -1,0 +1,24 @@
+import { useQuery } from '@tanstack/react-query'
+import { getProfitData } from './actions'
+import type { ProfitFilters } from './schemas'
+
+export const profitKeys = {
+  all: ['profit'] as const,
+  data: (filters: ProfitFilters) => ['profit', 'data', filters] as const,
+}
+
+export const useProfitDataQuery = (filters: ProfitFilters | null) => {
+  return useQuery({
+    // eslint-disable-next-line @tanstack/query/exhaustive-deps
+    queryKey: filters ? profitKeys.data(filters) : profitKeys.all,
+    queryFn: async () => {
+      if (!filters) return null
+      const result = await getProfitData(filters)
+      if (result.serverError) throw new Error(String(result.serverError))
+      if (result.validationErrors) throw new Error('Ошибка валидации входных данных')
+      if (!result.data) throw new Error('Сервер не вернул данные')
+      return result.data
+    },
+    enabled: !!filters,
+  })
+}

--- a/src/features/finances/profit/schemas.ts
+++ b/src/features/finances/profit/schemas.ts
@@ -1,0 +1,8 @@
+import * as z from 'zod'
+
+export const ProfitFiltersSchema = z.object({
+  startDate: z.string(),
+  endDate: z.string(),
+})
+
+export type ProfitFilters = z.infer<typeof ProfitFiltersSchema>

--- a/src/features/finances/profit/types.ts
+++ b/src/features/finances/profit/types.ts
@@ -1,0 +1,61 @@
+export interface TaxBreakdown {
+  taxSystem: string
+  taxSystemLabel: string
+  incomeTax: number
+  incomeTaxRate: number
+  insuranceContributions: number
+  fixedContributions: number
+}
+
+export interface AcquiringBreakdownItem {
+  methodName: string
+  commissionPercent: number
+  paymentSum: number
+  fee: number
+}
+
+export interface AcquiringData {
+  total: number
+  breakdown: AcquiringBreakdownItem[]
+}
+
+export interface SalaryData {
+  total: number
+  totalFromLessons: number
+  totalFromPaychecks: number
+  teacherCount: number
+  lessonCount: number
+}
+
+export interface RentData {
+  total: number
+  breakdown: RentBreakdownItem[]
+}
+
+export interface RentBreakdownItem {
+  locationName: string
+  amount: number
+}
+
+export interface ExpenseData {
+  total: number
+  breakdown: ExpenseBreakdownItem[]
+}
+
+export interface ExpenseBreakdownItem {
+  name: string
+  amount: number
+}
+
+export interface ProfitData {
+  revenue: number
+  taxes: {
+    total: number
+    breakdown: TaxBreakdown
+  }
+  acquiring: AcquiringData
+  salaries: SalaryData
+  rent: RentData
+  expenses: ExpenseData
+  profit: number
+}

--- a/src/features/finances/rent/actions.ts
+++ b/src/features/finances/rent/actions.ts
@@ -1,0 +1,49 @@
+'use server'
+
+import prisma from '@/src/lib/db/prisma'
+import { authAction } from '@/src/lib/safe-action'
+import { CreateRentSchema, DeleteRentSchema, UpdateRentSchema } from './schemas'
+
+export const getRents = authAction.metadata({ actionName: 'getRents' }).action(async ({ ctx }) => {
+  return await prisma.rent.findMany({
+    where: {
+      organizationId: ctx.session.organizationId!,
+    },
+    include: { location: true },
+    orderBy: { startDate: 'desc' },
+  })
+})
+
+export const createRent = authAction
+  .metadata({ actionName: 'createRent' })
+  .inputSchema(CreateRentSchema)
+  .action(async ({ ctx, parsedInput }) => {
+    await prisma.rent.create({
+      data: {
+        ...parsedInput,
+        startDate: new Date(parsedInput.startDate),
+        endDate: new Date(parsedInput.endDate),
+        organizationId: ctx.session.organizationId!,
+      },
+    })
+  })
+
+export const updateRent = authAction
+  .metadata({ actionName: 'updateRent' })
+  .inputSchema(UpdateRentSchema)
+  .action(async ({ ctx, parsedInput }) => {
+    const { id, ...data } = parsedInput
+    await prisma.rent.update({
+      where: { id, organizationId: ctx.session.organizationId! },
+      data,
+    })
+  })
+
+export const deleteRent = authAction
+  .metadata({ actionName: 'deleteRent' })
+  .inputSchema(DeleteRentSchema)
+  .action(async ({ ctx, parsedInput }) => {
+    await prisma.rent.delete({
+      where: { id: parsedInput.id, organizationId: ctx.session.organizationId! },
+    })
+  })

--- a/src/features/finances/rent/components/add-rent-button.tsx
+++ b/src/features/finances/rent/components/add-rent-button.tsx
@@ -1,0 +1,71 @@
+'use client'
+
+import { Button } from '@/src/components/ui/button'
+import {
+  Dialog,
+  DialogClose,
+  DialogContent,
+  DialogDescription,
+  DialogFooter,
+  DialogHeader,
+  DialogTitle,
+  DialogTrigger,
+} from '@/src/components/ui/dialog'
+import { zodResolver } from '@hookform/resolvers/zod'
+import { Loader, Plus } from 'lucide-react'
+import { useState } from 'react'
+import { useForm } from 'react-hook-form'
+import { useRentCreateMutation } from '../queries'
+import { CreateRentSchema, type CreateRentSchemaType } from '../schemas'
+import RentForm from './rent-form'
+
+export default function AddRentButton() {
+  const [dialogOpen, setDialogOpen] = useState(false)
+  const createMutation = useRentCreateMutation()
+
+  const form = useForm<CreateRentSchemaType>({
+    resolver: zodResolver(CreateRentSchema),
+    defaultValues: {
+      locationId: undefined,
+      startDate: undefined,
+      endDate: undefined,
+      amount: undefined,
+      comment: undefined,
+    },
+  })
+
+  const onSubmit = (values: CreateRentSchemaType) => {
+    createMutation.mutate(values, {
+      onSuccess: () => {
+        form.reset()
+        setDialogOpen(false)
+      },
+    })
+  }
+
+  return (
+    <Dialog open={dialogOpen} onOpenChange={setDialogOpen}>
+      <DialogTrigger render={<Button size={'icon'} />}>
+        <Plus />
+      </DialogTrigger>
+      <DialogContent>
+        <DialogHeader>
+          <DialogTitle>Добавить аренду</DialogTitle>
+          <DialogDescription>Укажите локацию, период и сумму расхода</DialogDescription>
+        </DialogHeader>
+        <RentForm form={form} formId="create-rent-form" />
+        <DialogFooter>
+          <DialogClose render={<Button variant="outline" />}>Отмена</DialogClose>
+          <Button
+            type="button"
+            disabled={createMutation.isPending}
+            onClick={form.handleSubmit(onSubmit)}
+          >
+            {createMutation.isPending && <Loader className="animate-spin" />}
+            Создать
+          </Button>
+        </DialogFooter>
+      </DialogContent>
+    </Dialog>
+  )
+}

--- a/src/features/finances/rent/components/rent-actions.tsx
+++ b/src/features/finances/rent/components/rent-actions.tsx
@@ -1,0 +1,164 @@
+'use client'
+
+import {
+  AlertDialog,
+  AlertDialogCancel,
+  AlertDialogContent,
+  AlertDialogDescription,
+  AlertDialogFooter,
+  AlertDialogHeader,
+  AlertDialogTitle,
+} from '@/src/components/ui/alert-dialog'
+import { Button } from '@/src/components/ui/button'
+import {
+  Dialog,
+  DialogClose,
+  DialogContent,
+  DialogDescription,
+  DialogFooter,
+  DialogHeader,
+  DialogTitle,
+} from '@/src/components/ui/dialog'
+import {
+  DropdownMenu,
+  DropdownMenuContent,
+  DropdownMenuGroup,
+  DropdownMenuItem,
+  DropdownMenuSeparator,
+  DropdownMenuTrigger,
+} from '@/src/components/ui/dropdown-menu'
+import { zodResolver } from '@hookform/resolvers/zod'
+import { Loader, MoreVertical, Pen, Trash } from 'lucide-react'
+import { useState } from 'react'
+import { useForm } from 'react-hook-form'
+import { useRentDeleteMutation, useRentUpdateMutation } from '../queries'
+import { UpdateRentSchema, type UpdateRentSchemaType } from '../schemas'
+import type { RentWithLocation } from '../types'
+import RentForm from './rent-form'
+
+interface RentActionsProps {
+  rent: RentWithLocation
+}
+
+export default function RentActions({ rent }: RentActionsProps) {
+  const [open, setOpen] = useState(false)
+  const [confirmOpen, setConfirmOpen] = useState(false)
+  const [editDialogOpen, setEditDialogOpen] = useState(false)
+
+  const updateMutation = useRentUpdateMutation()
+  const deleteMutation = useRentDeleteMutation()
+
+  const form = useForm<UpdateRentSchemaType>({
+    resolver: zodResolver(UpdateRentSchema),
+    defaultValues: {
+      id: rent.id,
+      locationId: rent.locationId,
+      startDate:
+        rent.startDate instanceof Date
+          ? rent.startDate.toISOString().split('T')[0]
+          : String(rent.startDate).split('T')[0],
+      endDate:
+        rent.endDate instanceof Date
+          ? rent.endDate.toISOString().split('T')[0]
+          : String(rent.endDate).split('T')[0],
+      amount: rent.amount,
+      comment: rent.comment ?? undefined,
+    },
+  })
+
+  const handleDelete = () => {
+    deleteMutation.mutate(
+      { id: rent.id },
+      {
+        onSuccess: () => setConfirmOpen(false),
+      },
+    )
+  }
+
+  const onSubmit = (values: UpdateRentSchemaType) => {
+    updateMutation.mutate(values, {
+      onSuccess: () => {
+        setEditDialogOpen(false)
+        form.reset()
+      },
+    })
+  }
+
+  return (
+    <>
+      <DropdownMenu open={open} onOpenChange={setOpen}>
+        <DropdownMenuTrigger render={<Button variant="ghost" size="icon" />}>
+          <MoreVertical />
+        </DropdownMenuTrigger>
+
+        <DropdownMenuContent className="w-max">
+          <DropdownMenuGroup>
+            <DropdownMenuItem
+              onClick={() => {
+                setEditDialogOpen(true)
+                setOpen(false)
+              }}
+            >
+              <Pen />
+              Редактировать
+            </DropdownMenuItem>
+          </DropdownMenuGroup>
+          <DropdownMenuSeparator />
+          <DropdownMenuItem
+            variant="destructive"
+            onClick={() => {
+              setConfirmOpen(true)
+              setOpen(false)
+            }}
+          >
+            <Trash />
+            Удалить
+          </DropdownMenuItem>
+        </DropdownMenuContent>
+      </DropdownMenu>
+
+      <AlertDialog open={confirmOpen} onOpenChange={setConfirmOpen}>
+        <AlertDialogContent>
+          <AlertDialogHeader>
+            <AlertDialogTitle>Вы уверены, что хотите удалить аренду?</AlertDialogTitle>
+            <AlertDialogDescription>
+              Это действие удалит запись об аренде и не может быть отменено.
+            </AlertDialogDescription>
+          </AlertDialogHeader>
+
+          <AlertDialogFooter>
+            <AlertDialogCancel>Отмена</AlertDialogCancel>
+            <Button
+              variant="destructive"
+              disabled={deleteMutation.isPending}
+              onClick={handleDelete}
+            >
+              {deleteMutation.isPending ? <Loader className="animate-spin" /> : 'Удалить'}
+            </Button>
+          </AlertDialogFooter>
+        </AlertDialogContent>
+      </AlertDialog>
+
+      <Dialog open={editDialogOpen} onOpenChange={setEditDialogOpen}>
+        <DialogContent>
+          <DialogHeader>
+            <DialogTitle>Редактировать аренду</DialogTitle>
+            <DialogDescription>Обновите информацию о расходе на аренду</DialogDescription>
+          </DialogHeader>
+          <RentForm form={form} formId="edit-rent-form" />
+          <DialogFooter>
+            <DialogClose render={<Button variant="outline" />}>Отмена</DialogClose>
+            <Button
+              type="button"
+              disabled={updateMutation.isPending}
+              onClick={form.handleSubmit(onSubmit)}
+            >
+              {updateMutation.isPending && <Loader className="animate-spin" />}
+              Сохранить
+            </Button>
+          </DialogFooter>
+        </DialogContent>
+      </Dialog>
+    </>
+  )
+}

--- a/src/features/finances/rent/components/rent-expenses.tsx
+++ b/src/features/finances/rent/components/rent-expenses.tsx
@@ -1,0 +1,31 @@
+'use client'
+
+import {
+  Card,
+  CardAction,
+  CardContent,
+  CardDescription,
+  CardHeader,
+  CardTitle,
+} from '@/src/components/ui/card'
+import AddRentButton from './add-rent-button'
+import RentTable from './rent-table'
+
+export default function RentExpenses() {
+  return (
+    <div className="grid min-h-0 flex-1 grid-cols-1">
+      <Card>
+        <CardHeader>
+          <CardTitle>Аренда</CardTitle>
+          <CardDescription>Расходы на аренду помещений по локациям</CardDescription>
+          <CardAction>
+            <AddRentButton />
+          </CardAction>
+        </CardHeader>
+        <CardContent className="overflow-hidden">
+          <RentTable />
+        </CardContent>
+      </Card>
+    </div>
+  )
+}

--- a/src/features/finances/rent/components/rent-form.tsx
+++ b/src/features/finances/rent/components/rent-form.tsx
@@ -1,0 +1,154 @@
+'use client'
+
+import { CustomCombobox } from '@/src/components/custom-combobox'
+import { NumberInput } from '@/src/components/number-input'
+import { Button } from '@/src/components/ui/button'
+import { Calendar } from '@/src/components/ui/calendar'
+import { Field, FieldError, FieldGroup, FieldLabel } from '@/src/components/ui/field'
+import { Input } from '@/src/components/ui/input'
+import { Popover, PopoverContent, PopoverTrigger } from '@/src/components/ui/popover'
+import { useMappedLocationListQuery } from '@/src/features/locations/queries'
+import { normalizeDateOnly } from '@/src/lib/timezone'
+import { format } from 'date-fns'
+import { ru } from 'date-fns/locale'
+import { Calendar as CalendarIcon } from 'lucide-react'
+import { Controller, FieldValues, Path, UseFormReturn } from 'react-hook-form'
+
+interface RentFormProps<T extends FieldValues> {
+  form: UseFormReturn<T>
+  formId: string
+}
+
+export default function RentForm<T extends FieldValues>({ form, formId }: RentFormProps<T>) {
+  const { data: locations = [] } = useMappedLocationListQuery()
+
+  return (
+    <form id={formId}>
+      <FieldGroup>
+        {/* Location */}
+        <Controller
+          control={form.control}
+          name={'locationId' as Path<T>}
+          render={({ field, fieldState }) => (
+            <Field>
+              <FieldLabel>Локация</FieldLabel>
+              <CustomCombobox
+                items={locations}
+                value={
+                  field.value
+                    ? (locations.find((l) => l.value === String(field.value)) ?? null)
+                    : null
+                }
+                onValueChange={(item) => field.onChange(item ? Number(item.value) : undefined)}
+                placeholder="Выберите локацию"
+              />
+              {fieldState.invalid && <FieldError errors={[fieldState.error]} />}
+            </Field>
+          )}
+        />
+
+        {/* Start Date */}
+        <Controller
+          control={form.control}
+          name={'startDate' as Path<T>}
+          render={({ field, fieldState }) => (
+            <Field>
+              <FieldLabel>Дата начала</FieldLabel>
+              <Popover>
+                <PopoverTrigger
+                  render={<Button variant="outline" className="w-full font-normal" />}
+                >
+                  <CalendarIcon className="h-4 w-4" />
+                  {field.value
+                    ? format(new Date(field.value as string), 'd MMM yyyy', { locale: ru })
+                    : 'Выберите дату'}
+                </PopoverTrigger>
+                <PopoverContent className="w-auto p-0" align="start">
+                  <Calendar
+                    mode="single"
+                    selected={field.value ? new Date(field.value as string) : undefined}
+                    onSelect={(value) =>
+                      value && field.onChange(normalizeDateOnly(value).toISOString().split('T')[0])
+                    }
+                    locale={ru}
+                  />
+                </PopoverContent>
+              </Popover>
+              {fieldState.invalid && <FieldError errors={[fieldState.error]} />}
+            </Field>
+          )}
+        />
+
+        {/* End Date */}
+        <Controller
+          control={form.control}
+          name={'endDate' as Path<T>}
+          render={({ field, fieldState }) => (
+            <Field>
+              <FieldLabel>Дата окончания</FieldLabel>
+              <Popover>
+                <PopoverTrigger
+                  render={<Button variant="outline" className="w-full font-normal" />}
+                >
+                  <CalendarIcon className="h-4 w-4" />
+                  {field.value
+                    ? format(new Date(field.value as string), 'd MMM yyyy', { locale: ru })
+                    : 'Выберите дату'}
+                </PopoverTrigger>
+                <PopoverContent className="w-auto p-0" align="start">
+                  <Calendar
+                    mode="single"
+                    selected={field.value ? new Date(field.value as string) : undefined}
+                    onSelect={(value) =>
+                      value && field.onChange(normalizeDateOnly(value).toISOString().split('T')[0])
+                    }
+                    locale={ru}
+                  />
+                </PopoverContent>
+              </Popover>
+              {fieldState.invalid && <FieldError errors={[fieldState.error]} />}
+            </Field>
+          )}
+        />
+
+        {/* Amount */}
+        <Controller
+          control={form.control}
+          name={'amount' as Path<T>}
+          render={({ field, fieldState }) => (
+            <Field>
+              <FieldLabel htmlFor={`${formId}-amount`}>Сумма (₽)</FieldLabel>
+              <NumberInput
+                id={`${formId}-amount`}
+                placeholder="0"
+                {...field}
+                onChange={field.onChange}
+                value={field.value ?? ''}
+                aria-invalid={fieldState.invalid}
+              />
+              {fieldState.invalid && <FieldError errors={[fieldState.error]} />}
+            </Field>
+          )}
+        />
+
+        {/* Comment */}
+        <Controller
+          control={form.control}
+          name={'comment' as Path<T>}
+          render={({ field, fieldState }) => (
+            <Field>
+              <FieldLabel htmlFor={`${formId}-comment`}>Комментарий</FieldLabel>
+              <Input
+                id={`${formId}-comment`}
+                placeholder="Необязательный комментарий"
+                {...field}
+                value={field.value ?? ''}
+              />
+              {fieldState.invalid && <FieldError errors={[fieldState.error]} />}
+            </Field>
+          )}
+        />
+      </FieldGroup>
+    </form>
+  )
+}

--- a/src/features/finances/rent/components/rent-table.tsx
+++ b/src/features/finances/rent/components/rent-table.tsx
@@ -1,0 +1,281 @@
+'use client'
+
+import DataTable from '@/src/components/data-table'
+import TableFilter, { type TableFilterItem } from '@/src/components/table-filter'
+import { Button } from '@/src/components/ui/button'
+import { Calendar } from '@/src/components/ui/calendar'
+import { Input } from '@/src/components/ui/input'
+import { Popover, PopoverContent, PopoverTrigger } from '@/src/components/ui/popover'
+import { Skeleton } from '@/src/components/ui/skeleton'
+import { useMappedLocationListQuery } from '@/src/features/locations/queries'
+import { useTableSearchParams } from '@/src/hooks/use-table-search-params'
+import { formatDateOnly } from '@/src/lib/timezone'
+import {
+  ColumnDef,
+  getCoreRowModel,
+  getFacetedRowModel,
+  getFacetedUniqueValues,
+  getFilteredRowModel,
+  getPaginationRowModel,
+  getSortedRowModel,
+  useReactTable,
+} from '@tanstack/react-table'
+import {
+  endOfMonth,
+  endOfWeek,
+  format,
+  startOfMonth,
+  startOfWeek,
+  subMonths,
+  subWeeks,
+} from 'date-fns'
+import { ru } from 'date-fns/locale'
+import { Calendar as CalendarIcon, ChevronDown, X } from 'lucide-react'
+import { useMemo, useState } from 'react'
+import type { DateRange } from 'react-day-picker'
+import { useRentListQuery } from '../queries'
+import type { RentWithLocation } from '../types'
+import RentActions from './rent-actions'
+
+const datePresets = [
+  {
+    label: 'Текущий месяц',
+    getValue: () => ({
+      from: startOfMonth(new Date()),
+      to: endOfMonth(new Date()),
+    }),
+  },
+  {
+    label: 'Прошлый месяц',
+    getValue: () => ({
+      from: startOfMonth(subMonths(new Date(), 1)),
+      to: endOfMonth(subMonths(new Date(), 1)),
+    }),
+  },
+  {
+    label: 'Текущая неделя',
+    getValue: () => ({
+      from: startOfWeek(new Date(), { weekStartsOn: 1 }),
+      to: endOfWeek(new Date(), { weekStartsOn: 1 }),
+    }),
+  },
+  {
+    label: 'Прошлая неделя',
+    getValue: () => ({
+      from: startOfWeek(subWeeks(new Date(), 1), { weekStartsOn: 1 }),
+      to: endOfWeek(subWeeks(new Date(), 1), { weekStartsOn: 1 }),
+    }),
+  },
+]
+
+export default function RentTable() {
+  const { data: rents = [], isLoading, isError } = useRentListQuery()
+  const { data: locations = [] } = useMappedLocationListQuery()
+
+  const [selectedLocations, setSelectedLocations] = useState<TableFilterItem[]>([])
+  const [dateRange, setDateRange] = useState<DateRange | undefined>(undefined)
+  const [isCalendarOpen, setIsCalendarOpen] = useState(false)
+
+  // Client-side filtering
+  const filteredRents = useMemo(() => {
+    let result = rents
+
+    // Filter by location
+    if (selectedLocations.length > 0) {
+      const locationIds = new Set(selectedLocations.map((l) => Number(l.value)))
+      result = result.filter((r) => locationIds.has(r.locationId))
+    }
+
+    // Filter by date range overlap
+    if (dateRange?.from && dateRange?.to) {
+      const filterFrom = dateRange.from.getTime()
+      const filterTo = dateRange.to.getTime()
+      result = result.filter((r) => {
+        const rentStart = new Date(r.startDate).getTime()
+        const rentEnd = new Date(r.endDate).getTime()
+        return rentStart <= filterTo && rentEnd >= filterFrom
+      })
+    }
+
+    return result
+  }, [rents, selectedLocations, dateRange])
+
+  const columns: ColumnDef<RentWithLocation>[] = useMemo(
+    () => [
+      {
+        header: 'Локация',
+        accessorFn: (row) => row.location.name,
+        id: 'location',
+      },
+      {
+        header: 'Период',
+        id: 'period',
+        accessorFn: (row) => new Date(row.startDate).getTime(),
+        cell: ({ row }) => {
+          const start = formatDateOnly(row.original.startDate, {
+            day: 'numeric',
+            month: 'short',
+            year: 'numeric',
+          })
+          const end = formatDateOnly(row.original.endDate, {
+            day: 'numeric',
+            month: 'short',
+            year: 'numeric',
+          })
+          return `${start} – ${end}`
+        },
+      },
+      {
+        header: 'Сумма',
+        accessorKey: 'amount',
+        cell: ({ row }) =>
+          new Intl.NumberFormat('ru-RU', {
+            style: 'currency',
+            currency: 'RUB',
+            maximumFractionDigits: 0,
+          }).format(row.original.amount),
+      },
+      {
+        header: 'Комментарий',
+        accessorKey: 'comment',
+        cell: ({ row }) => (
+          <span className="text-muted-foreground">{row.original.comment || '—'}</span>
+        ),
+      },
+      {
+        id: 'actions',
+        cell: ({ row }) => <RentActions rent={row.original} />,
+      },
+    ],
+    [],
+  )
+
+  const { globalFilter, setGlobalFilter, pagination, setPagination, sorting, setSorting } =
+    useTableSearchParams({
+      search: true,
+      pagination: true,
+      sorting: true,
+    })
+
+  const table = useReactTable({
+    data: filteredRents,
+    columns,
+    getCoreRowModel: getCoreRowModel(),
+    getFilteredRowModel: getFilteredRowModel(),
+    getFacetedUniqueValues: getFacetedUniqueValues(),
+    getFacetedRowModel: getFacetedRowModel(),
+    globalFilterFn: (row, _columnId, filterValue) => {
+      const searchValue = String(filterValue).toLowerCase()
+      const locationName = row.original.location.name.toLowerCase()
+      const comment = (row.original.comment ?? '').toLowerCase()
+      return locationName.includes(searchValue) || comment.includes(searchValue)
+    },
+    onPaginationChange: setPagination,
+    getPaginationRowModel: getPaginationRowModel(),
+    onSortingChange: setSorting,
+    getSortedRowModel: getSortedRowModel(),
+    state: {
+      globalFilter,
+      pagination,
+      sorting,
+    },
+  })
+
+  const handlePresetSelect = (preset: (typeof datePresets)[0]) => {
+    setDateRange(preset.getValue())
+    setIsCalendarOpen(false)
+  }
+
+  const formatDateRange = () => {
+    if (!dateRange?.from) return 'Все периоды'
+    if (!dateRange.to) return format(dateRange.from, 'd MMM yyyy', { locale: ru })
+    return `${format(dateRange.from, 'd MMM', { locale: ru })} – ${format(dateRange.to, 'd MMM yyyy', { locale: ru })}`
+  }
+
+  if (isLoading) {
+    return (
+      <div className="flex flex-col gap-3">
+        <Skeleton className="h-9 w-full" />
+        <Skeleton className="h-64 w-full" />
+      </div>
+    )
+  }
+
+  if (isError) {
+    return <div className="text-destructive">Ошибка при загрузке данных аренды.</div>
+  }
+
+  return (
+    <DataTable
+      table={table}
+      emptyMessage="Нет записей об аренде."
+      showPagination
+      toolbar={
+        <div className="flex flex-col gap-2 md:flex-row md:items-end">
+          <Input
+            value={globalFilter}
+            onChange={(e) => setGlobalFilter(e.target.value)}
+            placeholder="Поиск..."
+            className="md:max-w-60"
+          />
+
+          <TableFilter
+            label="Локация"
+            items={locations}
+            value={selectedLocations}
+            onChange={setSelectedLocations}
+          />
+
+          <div className="flex items-end gap-1">
+            <Popover open={isCalendarOpen} onOpenChange={setIsCalendarOpen}>
+              <PopoverTrigger
+                render={
+                  <Button variant="outline" className="min-w-44 justify-start gap-2">
+                    <CalendarIcon className="h-4 w-4" />
+                    <span className="truncate">{formatDateRange()}</span>
+                    <ChevronDown className="ml-auto h-4 w-4 opacity-50" />
+                  </Button>
+                }
+              />
+              <PopoverContent className="w-auto p-0" align="start">
+                <div className="flex">
+                  <div className="border-r p-2">
+                    <div className="text-muted-foreground mb-2 px-2 text-xs font-medium">
+                      Быстрый выбор
+                    </div>
+                    <div className="flex flex-col gap-1">
+                      {datePresets.map((preset) => (
+                        <Button
+                          key={preset.label}
+                          variant="ghost"
+                          className="justify-start text-xs"
+                          onClick={() => handlePresetSelect(preset)}
+                        >
+                          {preset.label}
+                        </Button>
+                      ))}
+                    </div>
+                  </div>
+                  <Calendar
+                    mode="range"
+                    defaultMonth={dateRange?.from}
+                    selected={dateRange}
+                    onSelect={setDateRange}
+                    locale={ru}
+                    numberOfMonths={2}
+                  />
+                </div>
+              </PopoverContent>
+            </Popover>
+
+            {dateRange && (
+              <Button variant="ghost" size="icon" onClick={() => setDateRange(undefined)}>
+                <X className="h-4 w-4" />
+              </Button>
+            )}
+          </div>
+        </div>
+      }
+    />
+  )
+}

--- a/src/features/finances/rent/queries.ts
+++ b/src/features/finances/rent/queries.ts
@@ -1,0 +1,77 @@
+import { useMutation, useQuery, useQueryClient } from '@tanstack/react-query'
+import { toast } from 'sonner'
+import { createRent, deleteRent, getRents, updateRent } from './actions'
+import type { CreateRentSchemaType, DeleteRentSchemaType, UpdateRentSchemaType } from './schemas'
+
+export const rentKeys = {
+  all: ['rents'] as const,
+  lists: () => [...rentKeys.all, 'list'] as const,
+}
+
+export const useRentListQuery = () => {
+  return useQuery({
+    queryKey: rentKeys.all,
+    queryFn: async () => {
+      const { data, serverError } = await getRents()
+      if (serverError) throw serverError
+      return data ?? []
+    },
+  })
+}
+
+export const useRentCreateMutation = () => {
+  const queryClient = useQueryClient()
+
+  return useMutation({
+    mutationFn: async (values: CreateRentSchemaType) => {
+      const { data, serverError } = await createRent(values)
+      if (serverError) throw serverError
+      return data
+    },
+    onSuccess: () => {
+      queryClient.invalidateQueries({ queryKey: rentKeys.all })
+      toast.success('Аренда успешно добавлена!')
+    },
+    onError: () => {
+      toast.error('Ошибка при добавлении аренды.')
+    },
+  })
+}
+
+export const useRentUpdateMutation = () => {
+  const queryClient = useQueryClient()
+
+  return useMutation({
+    mutationFn: async (values: UpdateRentSchemaType) => {
+      const { data, serverError } = await updateRent(values)
+      if (serverError) throw serverError
+      return data
+    },
+    onSuccess: () => {
+      queryClient.invalidateQueries({ queryKey: rentKeys.all })
+      toast.success('Аренда успешно обновлена!')
+    },
+    onError: () => {
+      toast.error('Ошибка при обновлении аренды.')
+    },
+  })
+}
+
+export const useRentDeleteMutation = () => {
+  const queryClient = useQueryClient()
+
+  return useMutation({
+    mutationFn: async (values: DeleteRentSchemaType) => {
+      const { data, serverError } = await deleteRent(values)
+      if (serverError) throw serverError
+      return data
+    },
+    onSuccess: () => {
+      queryClient.invalidateQueries({ queryKey: rentKeys.all })
+      toast.success('Аренда успешно удалена!')
+    },
+    onError: () => {
+      toast.error('Не удалось удалить аренду.')
+    },
+  })
+}

--- a/src/features/finances/rent/schemas.ts
+++ b/src/features/finances/rent/schemas.ts
@@ -1,0 +1,23 @@
+import * as z from 'zod'
+
+export const RentBaseSchema = z.object({
+  locationId: z.int().positive('Выберите локацию'),
+  startDate: z.string('Укажите дату начала'),
+  endDate: z.string('Укажите дату окончания'),
+  amount: z.int().positive('Сумма должна быть больше 0'),
+  comment: z.string().max(200, 'Комментарий не должен превышать 200 символов').optional(),
+})
+
+export const CreateRentSchema = RentBaseSchema
+
+export const UpdateRentSchema = RentBaseSchema.partial().extend({
+  id: z.int().positive(),
+})
+
+export const DeleteRentSchema = z.object({
+  id: z.int().positive(),
+})
+
+export type CreateRentSchemaType = z.infer<typeof CreateRentSchema>
+export type UpdateRentSchemaType = z.infer<typeof UpdateRentSchema>
+export type DeleteRentSchemaType = z.infer<typeof DeleteRentSchema>

--- a/src/features/finances/rent/types.ts
+++ b/src/features/finances/rent/types.ts
@@ -1,0 +1,3 @@
+import { Prisma } from '@/prisma/generated/client'
+
+export type RentWithLocation = Prisma.RentGetPayload<{ include: { location: true } }>

--- a/src/lib/features/registry.ts
+++ b/src/lib/features/registry.ts
@@ -17,6 +17,7 @@ export const FEATURE_KEYS = [
   'finances.salaries',
   'finances.advances',
   'finances.paymentMethods',
+  'finances.profit',
   'shop',
   'shop.products',
   'shop.categories',
@@ -53,6 +54,7 @@ export const FEATURE_REGISTRY: Record<FeatureKey, FeatureEntry> = {
   'finances.salaries': { label: 'Зарплаты', parent: 'finances' },
   'finances.unprocessedPayments': { label: 'Неразобранное', parent: 'finances' },
   'finances.paymentMethods': { label: 'Методы оплаты', parent: 'finances' },
+  'finances.profit': { label: 'Прибыль', parent: 'finances' },
 
   // - Магазин -
   shop: { label: 'Магазин' },

--- a/src/lib/features/route-feature-map.ts
+++ b/src/lib/features/route-feature-map.ts
@@ -21,6 +21,7 @@ const ROUTE_FEATURE_MAP: [RegExp, string][] = [
   [/^\/finances\/revenue/, 'finances.revenue'],
   [/^\/finances\/advances/, 'finances.advances'],
   [/^\/finances\/salaries/, 'finances.salaries'],
+  [/^\/finances\/profit/, 'finances.profit'],
   [/^\/finances/, 'finances'],
   [/^\/finances\/payment-methods/, 'finances.paymentMethods'],
 


### PR DESCRIPTION
## Summary

Adds financial management features: rent tracking, other expenses, and a profit calculation dashboard.

### Changes

- **Prisma**: Add `Rent` and `Expense` models with migrations
- **Rent**: Full CRUD for rent management (create, edit, delete rent entries)
- **Expenses**: Full CRUD for other expenses management
- **Profit**: Profit calculation dashboard aggregating revenue, rent, expenses, and teacher salaries
- **Navigation**: Add profit, rent, and expenses to sidebar navigation and feature registry